### PR TITLE
Fix for AoE targeting

### DIFF
--- a/Source/AllModdingComponents/CompAbilityUser/Verb_UseAbility.cs
+++ b/Source/AllModdingComponents/CompAbilityUser/Verb_UseAbility.cs
@@ -73,11 +73,11 @@ namespace AbilityUser
                 //Handle friendly fire targets.
                 if (!this.UseAbilityProps.TargetAoEProperties.friendlyFire)
                 {
-                    targets = this.caster.Map.listerThings.AllThings.Where(x => (x.Position.InHorDistOf(aoeStartPosition, this.UseAbilityProps.TargetAoEProperties.range)) && (x.GetType() == this.UseAbilityProps.TargetAoEProperties.targetClass) && !x.Faction.HostileTo(Faction.OfPlayer)).ToList<Thing>();
+                    targets = this.caster.Map.listerThings.AllThings.Where(x => (x.Position.InHorDistOf(aoeStartPosition, this.UseAbilityProps.TargetAoEProperties.range)) && (this.UseAbilityProps.TargetAoEProperties.targetClass.IsAssignableFrom(x.GetType())) && !x.Faction.HostileTo(Faction.OfPlayer)).ToList<Thing>();
                 }
                 else if ((this.UseAbilityProps.TargetAoEProperties.targetClass == typeof(Plant)) || (this.UseAbilityProps.TargetAoEProperties.targetClass == typeof(Building)))
                 {
-                    targets = this.caster.Map.listerThings.AllThings.Where(x => (x.Position.InHorDistOf(aoeStartPosition, this.UseAbilityProps.TargetAoEProperties.range)) && (x.GetType() == this.UseAbilityProps.TargetAoEProperties.targetClass)).ToList<Thing>();
+                    targets = this.caster.Map.listerThings.AllThings.Where(x => (x.Position.InHorDistOf(aoeStartPosition, this.UseAbilityProps.TargetAoEProperties.range)) && (this.UseAbilityProps.TargetAoEProperties.targetClass.IsAssignableFrom(x.GetType()))).ToList<Thing>();
                     foreach (Thing targ in targets)
                     {
                         LocalTargetInfo tinfo = new LocalTargetInfo(targ);
@@ -91,7 +91,7 @@ namespace AbilityUser
                     targets.Clear();
                     targets = this.caster.Map.listerThings.AllThings.Where(x =>
                         (x.Position.InHorDistOf(aoeStartPosition, this.UseAbilityProps.TargetAoEProperties.range)) &&
-                        (x.GetType() == this.UseAbilityProps.TargetAoEProperties.targetClass) &&
+                        (this.UseAbilityProps.TargetAoEProperties.targetClass.IsAssignableFrom(x.GetType())) &&
                         (x.HostileTo(Faction.OfPlayer) || this.UseAbilityProps.TargetAoEProperties.friendlyFire)).ToList<Thing>();
                 }
 


### PR DESCRIPTION
The AoE targeting algorithm does not account for subclasses of the
target class, so it will fail if the ability is cast on them. This fixes
the error.