### PR TITLE
Added stuffCost to World Recipes

### DIFF
--- a/Languages/English/Keyed/Eng_WorldObjectMods.xml
+++ b/Languages/English/Keyed/Eng_WorldObjectMods.xml
@@ -3,6 +3,7 @@
 
 <JecsTools_WorldObjectConst_AbandonReason>because no caravan is available at this location</JecsTools_WorldObjectConst_AbandonReason>
 <JecsTools_WorldObjectConst_ResourcesNeeded>Resources: {0}</JecsTools_WorldObjectConst_ResourcesNeeded>
-<JecsTools_WorldObjectConst_NotEnoughStuff>Failed. {1} of {0} materials required.</JecsTools_WorldObjectConst_NotEnoughStuff>
-
+<JecsTools_WorldObjectConst_NotEnoughThings>Missing Specific Items. Need {1}x {2}, have only {0}</JecsTools_WorldObjectConst_NotEnoughThings>
+<JecsTools_WorldObjectConst_NotEnoughStuff>Missing {2} Stuff. Need {1}x, have only {0}</JecsTools_WorldObjectConst_NotEnoughStuff>
+<JecsTools_WorldObjectConst_NotEnoughResources>Failed to build {0} due to lack of resources</JecsTools_WorldObjectConst_NotEnoughResources>
 </LanguageData>

--- a/Source/AllModdingComponents/JecsTools/CaravanJobs/WorldObjectBlueprint.cs
+++ b/Source/AllModdingComponents/JecsTools/CaravanJobs/WorldObjectBlueprint.cs
@@ -167,6 +167,55 @@ namespace JecsTools
                 };
         }
 
+        public void AddNumOfCheapestThings(List<Thing> allItems, Dictionary<Thing, int> toBeConsumed, ThingCountClass thingCount)
+        {
+            var matchingItemsPriceSorted = allItems.Where(thing => thing.def == thingCount.thingDef
+                                             && (toBeConsumed.TryGetValue(thing, out int value)
+                                                ? thing.stackCount > value : true))
+                                             .OrderBy(thing => thing.GetStatValue(StatDefOf.MarketValue));
+            int remainingCount = thingCount.count;
+            foreach(var thing in matchingItemsPriceSorted)
+            {
+                toBeConsumed.TryGetValue(thing, out int currentTaken);
+                int numberToTake = Math.Min(thing.stackCount - currentTaken, remainingCount);
+                if(currentTaken != 0)
+                    toBeConsumed[thing] += numberToTake;
+                else
+                    toBeConsumed.Add(thing, numberToTake);
+                remainingCount -= numberToTake;
+                if(remainingCount <= 0)
+                    break;
+            }
+
+            if(remainingCount > 0)
+                Log.ErrorOnce("JecsTools.WorldObjectBluePrint.AddNumOfCheapestThings: ran out of items before finding required amount. This should be checked before", 9534712);                                
+        }
+
+        public void AddNumOfCheapestStuff(List<Thing> allItems, Dictionary<Thing, int> toBeConsumed, StuffCategoryCountClass stuffCount)
+        {
+            var matchingItemsPriceSorted = allItems.Where(thing => ((thing?.Stuff?.stuffProps ?? thing.def.stuffProps)
+                                                                ?.categories?.Contains(stuffCount.stuffCatDef) ?? false)
+                                                            && (toBeConsumed.TryGetValue(thing, out int value) 
+                                                                ? thing.stackCount > value : true))
+                                                    .OrderBy(thing => thing.GetStatValue(StatDefOf.MarketValue));
+            int remainingCount = stuffCount.count;
+            foreach(var thing in matchingItemsPriceSorted)
+            {    
+                toBeConsumed.TryGetValue(thing, out int currentTaken);
+                int numberToTake = Math.Min(thing.stackCount - currentTaken, remainingCount);
+                if(currentTaken != 0)
+                    toBeConsumed[thing] += numberToTake;
+                else
+                    toBeConsumed.Add(thing, numberToTake);
+                remainingCount -= numberToTake;
+                if(remainingCount <= 0)
+                    break;
+            }
+
+            if(remainingCount > 0)
+                Log.ErrorOnce("JecsTools.WorldObjectBluePrint.AddNumOfCheapestStuff: ran out of items before finding required amount. This should be checked before", 9534713);      
+        }
+            
 
         public virtual bool CheckAndConsumeResources(Caravan c, WorldObjectRecipeDef recipe,
             bool consumeResources = true)
@@ -178,50 +227,51 @@ namespace JecsTools
             if (caravanInv == null || caravanInv.Count() == 0)
                 return false;
 
-            if (!recipe.stuffCategories.NullOrEmpty() && recipe.costStuffCount > 0)
-            {
-                var passed = false;
-                foreach (var t in recipe.stuffCategories)
-                {
-                    var yy = CaravanInventoryUtility.AllInventoryItems(c)
-                        .FindAll(x => x?.def?.stuffProps?.categories?.Contains(t) ?? false);
-                    if (!yy.NullOrEmpty())
-                    {
-                        var totalCount = yy.Sum(x => x.stackCount);
-                        if (totalCount - recipe.costStuffCount >= 0)
-                        {
-                            totalCount -= totalCount - recipe.costStuffCount;
-                            passed = true;
-                            foreach (var y in yy)
-                            {
-                                if (totalCount > 0)
-                                {
-                                    var math = Math.Min(y.stackCount, totalCount);
-                                    toBeConsumed.Add(y, math);
-                                    Log.Message(y + " x" + math);
-                                }
-                                totalCount -= y.stackCount;
-                            }
-                        }
-                    }
-                }
-                if (!passed && consumeResources)
-                {
-                    var categories = new string[recipe.stuffCategories.Count];
-                    for (var i = 0; i < recipe.stuffCategories.Count; i++)
-                        categories[i] = recipe.stuffCategories[i].label;
+            var passed = true;
+            var allItems = CaravanInventoryUtility.AllInventoryItems(c);
+            var missingResourcesMessage = new StringBuilder();
 
-                    Messages.Message(
-                        "JecsTools_WorldObjectConst_NotEnoughStuff".Translate(string.Join(", ", categories),
-                            recipe.costStuffCount), MessageTypeDefOf.RejectInput);
-                    return false;
+            foreach(var thingCount in recipe?.costList ?? Enumerable.Empty<ThingCountClass>()) 
+            {
+                int thingsFound = allItems.Where(thing => thing.def == thingCount.thingDef)
+                                          .Sum(thing => thing.stackCount);
+                if(thingsFound >= thingCount.count)
+                    AddNumOfCheapestThings(allItems, toBeConsumed, thingCount);
+                else {
+                    missingResourcesMessage.AppendLine("JecsTools_WorldObjectConst_NotEnoughThings"
+                                    .Translate(thingsFound, thingCount.count, thingCount.thingDef.LabelCap));
+                    passed = false;
                 }
             }
-            if (consumeResources)
+
+            foreach(var stuffCount in recipe?.stuffCostList ?? Enumerable.Empty<StuffCategoryCountClass>()) {
+                //Ensure I find stuffProps either under Stuff or def if any
+                int stuffFound = allItems.Where(thing => (thing?.Stuff?.stuffProps ?? thing.def.stuffProps)
+                                                            ?.categories?.Contains(stuffCount.stuffCatDef) ?? false)
+                                          .Sum(thing => thing.stackCount - 
+                                                    (toBeConsumed.TryGetValue(thing, out int value) ? value : 0));
+                if(stuffFound >= stuffCount.count)
+                    AddNumOfCheapestStuff(allItems, toBeConsumed, stuffCount);
+                else {
+                    missingResourcesMessage.AppendLine("JecsTools_WorldObjectConst_NotEnoughStuff"
+                                .Translate(stuffFound, stuffCount.count, stuffCount.stuffCatDef.LabelCap));
+                    passed = false;
+                }
+            }
+                               
+            if (!passed && consumeResources)
+            {
+                missingResourcesMessage.Insert(0, "JecsTools_WorldObjectConst_NotEnoughResources"
+                                                    .Translate(recipe.LabelCap) + Environment.NewLine);
+                Messages.Message(missingResourcesMessage.ToString(), MessageTypeDefOf.RejectInput);
+                return false;
+            }
+            
+            if (passed && consumeResources)
                 if (!ConsumeResources(c, toBeConsumed))
                     return false;
 
-            return true;
+            return passed;
         }
 
         public bool ConsumeResources(Caravan c, Dictionary<Thing, int> toBeConsumed)
@@ -266,16 +316,12 @@ namespace JecsTools
                         var amtFilled = resourcesSupplied ? t.count.ToString() : "0";
                         s.AppendLine(t.thingDef.LabelCap + ": " + amtFilled + " / " + t.count);
                     }
-                if (Recipe.stuffCategories != null && Recipe.costStuffCount > 0)
-                {
-                    var categories = new string[Recipe.stuffCategories.Count];
-                    for (var i = 0; i < Recipe.stuffCategories.Count; i++)
-                        categories[i] = Recipe.stuffCategories[i].LabelCap;
-                    var amtFilled = resourcesSupplied ? Recipe.costStuffCount.ToString() : "0";
-                    s.AppendLine(string.Join(", ", categories) + " " +
-                                 "JecsTools_WorldObjectConst_ResourcesNeeded".Translate(
-                                     amtFilled + " / " + Recipe.costStuffCount));
-                }
+                if(!Recipe.stuffCostList.NullOrEmpty())
+                    foreach(var stuffCat in Recipe.stuffCostList) 
+                    {
+                        var amtFilled = resourcesSupplied ? stuffCat.count.ToString() : "0";
+                        s.AppendLine(stuffCat.stuffCatDef.LabelCap + ": " + amtFilled + " / " + stuffCat.count);
+                    }
             }
             return s.ToString().TrimEndNewlines();
         }

--- a/Source/AllModdingComponents/JecsTools/CaravanJobs/WorldObjectRecipeDef.cs
+++ b/Source/AllModdingComponents/JecsTools/CaravanJobs/WorldObjectRecipeDef.cs
@@ -7,9 +7,8 @@ namespace JecsTools
     public class WorldObjectRecipeDef : Def
     {
         public List<ThingCountClass> costList;
-        public int costStuffCount = -1;
         public List<ResearchProjectDef> researchPrerequisites;
-        public List<StuffCategoryDef> stuffCategories;
+        public List<StuffCategoryCountClass> stuffCostList;
         public List<string> tags = new List<string>();
         public int workToMake = -1;
         public virtual Def FinishedThing { get; }

--- a/Source/AllModdingComponents/JecsTools/StuffCategoryCountClass.cs
+++ b/Source/AllModdingComponents/JecsTools/StuffCategoryCountClass.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Verse;
+using System.Xml;
+using RimWorld;
+
+namespace JecsTools
+{
+    //Based on Verse.ThingCountClass
+    public sealed class StuffCategoryCountClass
+    {
+        public StuffCategoryDef stuffCatDef;
+
+		public int count;
+
+        public string Summary {
+            get {
+                return this.count + "x " + ((this.stuffCatDef == null) ? "null" : this.stuffCatDef.label);
+            }
+        }
+
+        public StuffCategoryCountClass()
+        {
+        }
+
+        public StuffCategoryCountClass(StuffCategoryDef stuffCatDef, int count)
+        {
+            this.stuffCatDef = stuffCatDef;
+			this.count = count;
+        }
+
+        public void LoadDataFromXmlCustom(XmlNode xmlRoot)
+        {
+            if (xmlRoot.ChildNodes.Count != 1) {
+                Log.Error("Misconfigured StuffCategoryCount: " + xmlRoot.OuterXml);
+                return;
+            }
+            DirectXmlCrossRefLoader.RegisterObjectWantsCrossRef(this, "stuffCatDef", xmlRoot.Name);
+            this.count = (int)ParseHelper.FromString(xmlRoot.FirstChild.Value, typeof(int));
+        }
+
+        public override string ToString()
+        {
+            return string.Concat(new object[]
+            {
+                    "(",
+                    this.count,
+                    "x ",
+                    (this.stuffCatDef == null) ? "null" : this.stuffCatDef.defName,
+                    ")"
+            });
+        }
+        
+        public override int GetHashCode()
+        {
+            return (int)this.stuffCatDef.shortHash + this.count << 16;
+        }
+    }
+}


### PR DESCRIPTION
I've updated the WorldObjectRecipeDef to utilize both list of Thing costs as well as lists of stuff categories, for which I added a StuffCategoryCountClass as a counterpart to ThingCountClass. It will attempt to consume specific Things first and then look for Things that satisfy the given StuffCategoryDefs. 

As a note I did add/alter some of your Keyed translations, specifically regarding missing resource error messages.

My primary motivation for this was actually your RimRoad's mod, to which I'll be issuing a pull request shortly. Thanks for the great mods and let me know if you have any questions.