### PR TITLE
CompProperties_AnimatedOver

### DIFF
--- a/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
@@ -82,8 +82,8 @@ namespace CompAnimated
                 if (asPawn && (pAnimatee?.pather?.MovingNow ?? false))
                 {
                     pCurIndex = (pCurIndex + 1) % pProps.movingFrames.Count();
-                    if (pProps.sound != null) pProps.sound.PlayOneShot(SoundInfo.InMap(pAnimatee));
-                    result = ResolveCycledGraphic(pAnimatee, pProps, pCurIndex);
+                    pProps.sound?.PlayOneShot(SoundInfo.InMap(pAnimatee));
+                    result = ResolveCycledGraphic(pThingWithComps, pProps, pCurIndex);
                 }
                 else
                 {

--- a/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
@@ -8,7 +8,7 @@ namespace CompAnimated
 {
     public class CompAnimated : ThingComp
     {
-        private Graphic curGraphic;
+        protected Graphic curGraphic;
         public int curIndex;
 
         public bool dirty;
@@ -29,18 +29,17 @@ namespace CompAnimated
         public override void PostDraw()
         {
             if (parent is Pawn) return;
-
-            Log.Message("Post");
             base.PostDraw();
-            if (curGraphic == null)
-                return;
-            
-            Log.Message("Overlay");
-            Vector3 drawPos = this.parent.DrawPos;
+            if (curGraphic != null)
+                Render();
+        }
 
+        public virtual void Render()
+        {
+            Vector3 drawPos = this.parent.DrawPos;
             curGraphic.Draw(drawPos, Rot4.North, this.parent, 0f);
         }
-        
+
         public CompProperties_Animated Props => (CompProperties_Animated) props;
 
         public Graphic CurGraphic
@@ -50,7 +49,11 @@ namespace CompAnimated
                 if (curGraphic == null || dirty || !(parent is Pawn)) //Buildings and the like use us as a renderer.
                 {
                     var resolveCurGraphic = DefaultGraphic();
-                    curGraphic = resolveCurGraphic;
+                    if (resolveCurGraphic != null && resolveCurGraphic != curGraphic)
+                    {
+                        curGraphic = resolveCurGraphic;
+                        NotifyGraphicsChange();
+                    }
                 }
 
                 return curGraphic;
@@ -64,7 +67,7 @@ namespace CompAnimated
             return ResolveCurGraphic(pawn as ThingWithComps, pProps, ref result, ref pCurIndex, ref pTicksToCycle, ref pDirty, useBaseGraphic);
         }
 
-            public static Graphic ResolveCurGraphic(ThingWithComps pThingWithComps, CompProperties_Animated pProps, ref Graphic result,
+        public static Graphic ResolveCurGraphic(ThingWithComps pThingWithComps, CompProperties_Animated pProps, ref Graphic result,
             ref int pCurIndex, ref int pTicksToCycle, ref bool pDirty, bool useBaseGraphic = true)
         {
             if (pProps.secondsBetweenFrames <= 0.0f)
@@ -114,7 +117,7 @@ namespace CompAnimated
             return ResolveCycledGraphic(pAnimatee as ThingWithComps, pProps, pCurIndex);
         }
 
-            public static Graphic ResolveCycledGraphic(ThingWithComps pAnimatee, CompProperties_Animated pProps, int pCurIndex)
+        public static Graphic ResolveCycledGraphic(ThingWithComps pAnimatee, CompProperties_Animated pProps, int pCurIndex)
         {
             Graphic result = null;
             bool haveMovingFrames = !pProps.movingFrames.NullOrEmpty();
@@ -193,6 +196,11 @@ namespace CompAnimated
             base.PostExposeData();
             Scribe_Values.Look(ref curIndex, "curIndex", 0);
             Scribe_Values.Look(ref ticksToCycle, "ticksToCycle", -1);
+        }
+
+        public virtual void NotifyGraphicsChange()
+        {
+            
         }
     }
 }

--- a/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
@@ -203,7 +203,6 @@ namespace CompAnimated
 
         public virtual void NotifyGraphicsChange()
         {
-            Log.Message("Graphics Changed");
         }
     }
 }

--- a/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
@@ -103,13 +103,15 @@ namespace CompAnimated
         /** Primary call to above */
         private Graphic DefaultGraphic()
         {
-            var resolveCurGraphic =ResolveCurGraphic(parent, Props, ref curGraphic, ref curIndex, ref ticksToCycle, ref dirty);
-            if (resolveCurGraphic != null && resolveCurGraphic != curGraphic)
+            Graphic proxyGraphic = null;
+            var resolveCurGraphic = ResolveCurGraphic(parent, Props, ref proxyGraphic, ref curIndex, ref ticksToCycle, ref dirty);
+            if (proxyGraphic != null)
             {
-                curGraphic = resolveCurGraphic;
+                curGraphic = proxyGraphic;
                 NotifyGraphicsChange();
             }
-            return resolveCurGraphic;
+           
+            return resolveCurGraphic ?? curGraphic;
         }
 
         [Obsolete("ResolveCycledGraphic for pawns is deprecated, please use ResolveCycledGraphic for ThingWithComps instead.")]

--- a/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimated.cs
@@ -48,12 +48,7 @@ namespace CompAnimated
             {
                 if (curGraphic == null || dirty || !(parent is Pawn)) //Buildings and the like use us as a renderer.
                 {
-                    var resolveCurGraphic = DefaultGraphic();
-                    if (resolveCurGraphic != null && resolveCurGraphic != curGraphic)
-                    {
-                        curGraphic = resolveCurGraphic;
-                        NotifyGraphicsChange();
-                    }
+                    curGraphic = DefaultGraphic();
                 }
 
                 return curGraphic;
@@ -108,7 +103,13 @@ namespace CompAnimated
         /** Primary call to above */
         private Graphic DefaultGraphic()
         {
-            return ResolveCurGraphic(parent, Props, ref curGraphic, ref curIndex, ref ticksToCycle, ref dirty);
+            var resolveCurGraphic =ResolveCurGraphic(parent, Props, ref curGraphic, ref curIndex, ref ticksToCycle, ref dirty);
+            if (resolveCurGraphic != null && resolveCurGraphic != curGraphic)
+            {
+                curGraphic = resolveCurGraphic;
+                NotifyGraphicsChange();
+            }
+            return resolveCurGraphic;
         }
 
         [Obsolete("ResolveCycledGraphic for pawns is deprecated, please use ResolveCycledGraphic for ThingWithComps instead.")]
@@ -200,7 +201,7 @@ namespace CompAnimated
 
         public virtual void NotifyGraphicsChange()
         {
-            
+            Log.Message("Graphics Changed");
         }
     }
 }

--- a/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
@@ -17,8 +17,8 @@ namespace CompAnimated
             Vector3 drawPos = this.parent.DrawPos;
             
             //apply offset
-            drawPos.x += OverProps.xOffset + yOffset;
-            drawPos.y += OverProps.yOffset + xOffset;
+            drawPos.x += OverProps.xOffset + xOffset;
+            drawPos.z += OverProps.yOffset + yOffset;
             
             curGraphic.Draw(drawPos, Rot4.North, this.parent);
         }

--- a/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using Verse;
+
+namespace CompAnimated
+{
+    public class CompAnimatedOver : CompAnimated
+    {
+        /// <summary>
+        /// Additional programatic movement hooks 
+        /// </summary>
+        public float yOffset = 0f, xOffset = 0f, xScale = 1f, yScale = 1f;
+        
+        public CompProperties_AnimatedOver OverProps => (CompProperties_AnimatedOver) props;
+        
+        public override void Render()
+        {
+            Vector3 drawPos = this.parent.DrawPos;
+            
+            //apply offset
+            drawPos.x += OverProps.xOffset + yOffset;
+            drawPos.y += OverProps.yOffset + xOffset;
+            
+            curGraphic.Draw(drawPos, Rot4.North, this.parent);
+        }
+
+        public override void NotifyGraphicsChange()
+        {
+            //re scale once
+            curGraphic.drawSize.Scale(new Vector2(OverProps.xScale*xScale, OverProps.yScale*yScale));
+            base.NotifyGraphicsChange();
+        }
+
+        public void Invalidate()
+        {
+            curGraphic = null;
+            this.dirty = true;
+        }
+    }
+}

--- a/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
@@ -31,10 +31,6 @@ namespace CompAnimated
             var sz = curGraphic.drawSize;
             sz.Scale(vector2);
             scaled = curGraphic.GetCopy(sz);
-            //re scale once
-            
-            
-            Log.Message("Size: "+sz +" Scalar "+vector2);
             base.NotifyGraphicsChange();
         }
 

--- a/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompAnimatedOver.cs
@@ -5,6 +5,7 @@ namespace CompAnimated
 {
     public class CompAnimatedOver : CompAnimated
     {
+        protected Graphic scaled;
         /// <summary>
         /// Additional programatic movement hooks 
         /// </summary>
@@ -20,13 +21,20 @@ namespace CompAnimated
             drawPos.x += OverProps.xOffset + xOffset;
             drawPos.z += OverProps.yOffset + yOffset;
             
-            curGraphic.Draw(drawPos, Rot4.North, this.parent);
+            scaled.Draw(drawPos, Rot4.North, this.parent);
         }
 
         public override void NotifyGraphicsChange()
         {
+            var vector2 = new Vector2(OverProps.xScale*xScale, OverProps.yScale*yScale);
+            
+            var sz = curGraphic.drawSize;
+            sz.Scale(vector2);
+            scaled = curGraphic.GetCopy(sz);
             //re scale once
-            curGraphic.drawSize.Scale(new Vector2(OverProps.xScale*xScale, OverProps.yScale*yScale));
+            
+            
+            Log.Message("Size: "+sz +" Scalar "+vector2);
             base.NotifyGraphicsChange();
         }
 

--- a/Source/AllModdingComponents/CompAnimated/CompProperties_Animated.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompProperties_Animated.cs
@@ -14,5 +14,23 @@ namespace CompAnimated
         {
             compClass = typeof(CompAnimated);
         }
+
+        public override IEnumerable<string> ConfigErrors(ThingDef parentDef)
+        {
+            foreach (var error in base.ConfigErrors(parentDef))
+            {
+                yield return error;
+            }
+
+            if (stillFrames.NullOrEmpty() && movingFrames.NullOrEmpty())
+            {
+                yield return "Forgot to define stillFrame > li or movingFrame > li";
+            }
+            
+            if (secondsBetweenFrames<=0f)
+            {
+                yield return "Forgot to define secondsBetweenFrames";
+            }
+        }
     }
 }

--- a/Source/AllModdingComponents/CompAnimated/CompProperties_AnimatedOver.cs
+++ b/Source/AllModdingComponents/CompAnimated/CompProperties_AnimatedOver.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Verse;
+
+namespace CompAnimated
+{
+    public class CompProperties_AnimatedOver : CompProperties_Animated
+    {
+        public float yOffset = 0f, xOffset = 0f, xScale = 1f, yScale = 1f;
+        public CompProperties_AnimatedOver()
+        {
+            compClass = typeof(CompAnimatedOver);
+        }
+
+        public override IEnumerable<string> ConfigErrors(ThingDef parentDef)
+        {
+            foreach (var error in base.ConfigErrors(parentDef))
+            {
+                yield return error;
+            }
+
+            if (xScale <= 0f) 
+            {
+                xScale = 0f;
+                yield return "xScale must be positive";
+            }
+            
+            if (yScale <= 0f)
+            {
+                yScale = 0f;
+                yield return "yScale must be positive";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Cleanup for extension
Remove Logs,
add `Virtual Render Method` for class I want  to add,
add `virtual NotifyGraphicsChange` for same

Add CompProperties_AnimatedOver
  New child of `CompProperties_Animated` that allows xml and programatic instance hooks to move an animated image over a thing def. Not intended to be used by pawns unless scaling is needed.

Sample : 
![image](https://user-images.githubusercontent.com/464396/47634639-99c80f00-db28-11e8-8860-50c954ebe0c4.png)

Example Github: https://github.com/alycecil/CompProperties_AnimatedOverExample

Relevant Clip:
```
<comps>
...
            <li Class="CompAnimated.CompProperties_AnimatedOver">
                <secondsBetweenFrames>0.55</secondsBetweenFrames>
                <xOffset>-0.5</xOffset>
                <yOffset>1.1</yOffset>
                <stillFrames>
                    <li>
                        <texPath>yemma/demonfat</texPath>
                        <drawSize>0.5</drawSize>

                        <graphicClass>Graphic_Multi</graphicClass>
                    </li>
                    <li>
                        <texPath>yemma/demonfat_1</texPath>
                        <drawSize>0.5</drawSize>

                        <graphicClass>Graphic_Multi</graphicClass>
                    </li>
                </stillFrames>
                <sound/>
            </li>
            <li Class="CompAnimated.CompProperties_Animated">
                <secondsBetweenFrames>0.15</secondsBetweenFrames>
                <stillFrames>
                    <li>
                        <texPath>yemma/yemma_0</texPath>
                        <shaderType>CutoutComplex</shaderType>
                        <graphicClass>Graphic_Single</graphicClass>
                        <drawSize>(3,2)</drawSize>
                    </li>
...
```