### PR TITLE
Update Manifest.txt to fix warnings in console with mod Manager 

### DIFF
--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -1,34 +1,12 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
   <identifier>JecsTools</identifier>
   <version>1.1.1.2</version>
   <dependencies />
   <incompatibleWith />
-  <loadBefore>
-    <li>DoorsExpanded</li>
-    <li>CoC-Factions</li>
-    <li>CoC-Cults</li>
-    <li>CoC-ElderThings</li>
-    <li>HPLovecraftStoryteller</li>
-    <li>IA-ObjectsAndFurniture</li>
-    <li>IA-SteamCorp</li>
-    <li>LotR-Dwarves</li>
-    <li>LotR-Elves</li>
-    <li>LotR-Hobbits</li>
-    <li>LotR-MenAndBeasts</li>
-    <li>LotR-OrcsAndGoblins</li>
-    <li>LotR-TheThirdAge</li>
-    <li>RoM-Arachnophobia</li>
-    <li>RoM-Vampires</li>
-    <li>RoM-Werewolves</li>
-    <li>RimQuest</li>
-    <li>RimWriter</li>
-    <li>SW-Factions</li>
-    <li>SW-Lightsabers</li>
-    <li>SW-TheForce</li>
-  </loadBefore>
+  <loadBefore />
   <loadAfter>
-    <li>HugsLib</li>
+    <li>UnlimitedHugs.HugsLib</li>
   </loadAfter>
   <manifestUri>https://raw.githubusercontent.com/jecrell/JecsTools/master/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/jecrell/JecsTools/releases</downloadUri>


### PR DESCRIPTION
it's better to remove the dependencies of load before in jecstools and add in each mod manifest.txt in the section load after: jecrell.jecstools, because if you don't have that mod it will give a warning in the console and the hugslib change it's because for mod manager it's easier to find the mod with the package id (it still works with the name but in the console you will have a message saying that the name was converted to the package id of the mod)
![image](https://user-images.githubusercontent.com/46250330/86367188-efe54200-bc7b-11ea-9411-bc75aa52d04d.png)
