### PR TITLE
optimize AreAllies

### DIFF
--- a/Source/AllModdingComponents/AbilityUserAI/Utility/AbilityUtility.cs
+++ b/Source/AllModdingComponents/AbilityUserAI/Utility/AbilityUtility.cs
@@ -93,25 +93,23 @@ namespace AbilityUserAI
         }
 
         /// <summary>
-        ///     Convenience function for checking whether the pawns are allies.
+        ///     Convenience function for checking whether the pawns are allies. Handles null Factions.
         /// </summary>
         /// <param name="first">Initiator pawn that is checking.</param>
         /// <param name="second">Second pawn to check with.</param>
         /// <returns>True if they are allies. False if not.</returns>
         public static bool AreAllies(Thing first, Thing second)
         {
-            //If you are yourself, then you are definitely allies.
-            if (first == second)
+            //You are allies with yourself and others in your factions. Treat null as a faction
+            if (first.Faction == second.Faction)
                 return true;
 
-            //Null factions are allies.
-            if (first.Faction == null && second.Faction == null)
-                return true;
+            //Otherwise, null Factions are not allies with non-null Factions
+            if (first.Faction == null || second.Faction == null)
+                return false;
 
-            //Be allies if in the same Faction or if the goodwill with the other Faction is abouve 50%.
-            if (second.Faction == null)
-                return first.Faction == second.Faction;
-            return first.Faction == second.Faction || first.Faction.GoodwillWith(second.Faction) >= 0.5f;
+            //Be allies if the goodwill with the other Faction is above 50%.
+            return first.Faction.GoodwillWith(second.Faction) >= 0.5f;
         }
 
         /// <summary>


### PR DESCRIPTION
Improvements
- Reduces comparisons by an average of 1 per call to AreAllies. 
- Fixes error if first.Faction is null and second.Faction is not.

Possible Regression
- The case of first == second now has an Unhandled Exception when first and second == null. I believe first and second are never supposed to be null as the throw this exception when first or second are null but not both. If this is a regression, adding if(first == second) return true; as the first line will fix and it will still be on average faster (at worst the same) as the previous function.


Sorry if this is an unnecessary PR. I'm trying to introduce myself to forking and modding Rimworld while practicing some C#.

![image](https://user-images.githubusercontent.com/21249976/172993728-681905c7-7e31-4c18-a314-51471f27319c.png)

