### PR TITLE
Avoid hardcoding Version.txt folder, parity with DoorsExpanded

### DIFF
--- a/Source/AllModdingComponents/Directory.Build.props
+++ b/Source/AllModdingComponents/Directory.Build.props
@@ -8,7 +8,7 @@
     <NoStdLib>true</NoStdLib>
     <LangVersion>10.0</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Version>$([System.IO.File]::ReadAllText("C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Workspace\JecsTools\About\Version.txt"))</Version>
+    <Version>$([System.IO.File]::ReadAllText("$(SolutionDir)\..\About\Version.txt"))</Version>
     <!--
     For some reason, although SDK projects should default Deterministic to true, when importing this props file,
     builds become non-deterministic unless Deterministic is explicitly set to true here.

--- a/Source/AllModdingComponents/Directory.Build.props
+++ b/Source/AllModdingComponents/Directory.Build.props
@@ -3,12 +3,12 @@
 <Project>
   <PropertyGroup>
     <Configurations>RW1.4;RW1.4Unstable</Configurations>
-    <Configuration Condition=" '$(Configuration)' == '' ">RW1.4Unstable</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' Or '$(Configuration)' == 'Debug' ">RW1.4Unstable</Configuration>
     <TargetFramework>net472</TargetFramework>
     <NoStdLib>true</NoStdLib>
     <LangVersion>10.0</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Version>$([System.IO.File]::ReadAllText("$(SolutionDir)\..\About\Version.txt"))</Version>
+    <Version>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)\..\..\..\About\Version.txt"))</Version>
     <!--
     For some reason, although SDK projects should default Deterministic to true, when importing this props file,
     builds become non-deterministic unless Deterministic is explicitly set to true here.

--- a/Source/AllModdingComponents/JecsTools/PlaceWorker_OnTopOfWalls.cs
+++ b/Source/AllModdingComponents/JecsTools/PlaceWorker_OnTopOfWalls.cs
@@ -14,8 +14,8 @@ namespace JecsTools
 
         static bool IsWall(Thing thing)
         {
-            // In RW 1.3+, it seems like BuildingProperties.isPlaceOverableWall indicates whether something is a "wall".
-            if (thing.def.building?.isPlaceOverableWall ?? false)
+            // In RW 1.3+, it seems like BuildingProperties.isPlaceOverableWall or ThingDef.IsSmoothed indicates whether something is a "wall".
+            if (thing.def is { building: { isPlaceOverableWall: true } } or { IsSmoothed: true })
                 return true;
             // Legacy heuristic for mods that don't use isPlaceOverableWall.
             if (thing.def.defName.Contains("Wall"))


### PR DESCRIPTION
1. Avoid hardcoding Version.txt folder in Directory.Build.props and fix `dotnet build` on individual projects
2. Update PlaceWorker_OnTopOfWalls to consider smoothed buildings as walls (parity with DoorsExpanded)

2nd one is another change I forgot to merge in last year